### PR TITLE
Fix file path resolution for Windows

### DIFF
--- a/lib/transform_sass.dart
+++ b/lib/transform_sass.dart
@@ -86,7 +86,11 @@ class TransformSass extends bb.AggregateTransformer {
           // "/home/user/dart_projects/project/lib/"
           value = dir.parent.absolute.path + "/lib/";
         }
-        var uri = new Uri.file(value.replaceFirst("file://", ""));
+
+        if (Platform.isWindows) value = value.replaceFirst("file:///", "");
+        else value = value.replaceFirst("file://", "");
+
+        var uri = new Uri.file(value);
         // "library" : "/home/user/.pub-cache/hosted/.../lib/"
         // **or**
         // "project" : "/home/user/dart-projects/project/lib/"


### PR DESCRIPTION
Originally, paths were being modified to keep initial forward slashes when paths were fully qualified (stuff like `file:///home/user -> /home/user`). However, this doesn't work correctly on Windows as it will produce a URI like `/C:/...` from `file:///C:/...`. This causes the `Uri.file` constructor to fail with an error saying "Invalid argument(s): Illegal character in path". Simple fix was to trim all of `file:///` on Windows and just `file://` for other OS's.

Awesome package though! 😄 